### PR TITLE
feat(ada): add NPC profile details

### DIFF
--- a/_npcs/ada-wester.html
+++ b/_npcs/ada-wester.html
@@ -1,0 +1,20 @@
+---
+identifier: "c2776f4a-e9aa-4d61-85c9-fc695ebe8128"
+name: "Ada Wester"
+image: "ada-wester.jpg"
+species: "komodo dragon"
+gender: "female"
+occupation: "Secretary"
+lastSeen: "Phandalin"
+isAlive: true
+---
+<p>
+    A kindly, gentle woman who deals with the town's residents in place of her husband, Harbin, when it comes to
+    complaints, feedback, and planning requests. She hopes that by filtering out the noise and absurd requests,
+    her husband will have an easier time and be less stressed and vocal. That's yet to happen.
+</p>
+<p>
+    Although she may show open displeasure for his loud rants and questionable interactions with people, she
+    does love her husband deeply and hopes that old age will cause to mellow out. And if not, she'll be right
+    there to pull him in line.
+</p>


### PR DESCRIPTION
Adds Ada Wester (wife of Harbin Wester, the mayor) in order to tie up the loose end with him having a wife even though the players have never met her.
