### PR TITLE
feat(location): make main labels clickable and link to correct modal

### DIFF
--- a/_sass/locations.scss
+++ b/_sass/locations.scss
@@ -116,6 +116,33 @@
   }
 }
 
-#markers > svg, #burgLabel3 {
+#markers > svg, #label1,
+#markers > svg, #label2,
+#markers > svg, #stateLabel23,
+
+#markers > svg, #stateLabel19,
+#markers > svg, #stateLabel20,
+#markers > svg, #stateLabel6,
+#markers > svg, #stateLabel14,
+#markers > svg, #stateLabel11,
+#markers > svg, #stateLabel3,
+#markers > svg, #stateLabel16,
+#markers > svg, #stateLabel10,
+
+#markers > svg, #burgLabel3,
+#markers > svg, #burgLabel240,
+
+#markers > svg, #stateLabel18,
+#markers > svg, #stateLabel13,
+#markers > svg, #stateLabel12,
+#markers > svg, #stateLabel15,
+#markers > svg, #stateLabel9,
+#markers > svg, #stateLabel2,
+#markers > svg, #stateLabel21,
+#markers > svg, #stateLabel1,
+#markers > svg, #stateLabel7,
+
+#markers > svg, #stateLabel22,
+{
   cursor: pointer;
 }

--- a/assets/js/locations.js
+++ b/assets/js/locations.js
@@ -34,10 +34,41 @@ function initLocations() {
     addTooltipToMapMarker("50905b22-27d5-496c-aa27-d2c90659f8ff", "Windsore Planes", "marker71")
 
     // For now this will be manual. Maybe later I will automate this
-    const profanedCapital = document.getElementById("burgLabel3");
-    profanedCapital.addEventListener("click", function () {
-        showModal("59af4720-25af-4d9c-a814-c71afa539542", "{{site.locationUrlKey}}")
-    })
+    const labels = [
+        [document.getElementById("label1"), "580c0304-e112-4bcf-84ca-4823902bcf14"], //Zyxs
+        [document.getElementById("label2"), "607d1a32-e2de-4cb2-b9f6-4188636e4609"], //Navirar
+        [document.getElementById("stateLabel23"), "2346b690-8428-47ae-9cdf-dc346616c123"], //Kingdom of Five Emperors
+
+        [document.getElementById("stateLabel19"), "1f32c7d5-5352-439b-b1bc-b5d228963b39"], //Malgalus
+        [document.getElementById("stateLabel20"), "2dd41b8c-e114-4ccf-8dfe-f712b78b5e25"], //Rathex
+        [document.getElementById("stateLabel6"), "625a3220-62bc-4140-a452-93ae1f7c32a0"], //Andoril
+        [document.getElementById("stateLabel14"), "6dcbac0b-83ee-48b2-b1fe-1be6144aecd0"], //Hala'Shu
+        [document.getElementById("stateLabel11"), "e53774fe-ab52-4845-92de-aedbea8038d1"], //Vuloth
+        [document.getElementById("stateLabel3"), "9dcc0ed7-71d9-4ae0-9d9c-a4a754d92be8"], //Tsendoric
+        [document.getElementById("stateLabel16"), "502055c5-cc2a-4f9a-b4d0-7c1a2e872873"], //Zarak
+        [document.getElementById("stateLabel10"), "7ef34938-e1b5-474d-a0d2-5cac2fd17a09"], //Dalortha
+
+        [document.getElementById("burgLabel3"), "59af4720-25af-4d9c-a814-c71afa539542"], //Profaned Capital
+        [document.getElementById("burgLabel240"), "e304ce6e-917c-4c61-b48a-2788045ed5c9"], //Baldur's Gate
+
+        [document.getElementById("stateLabel18"), "c41a9f01-05ff-4482-91d0-85db7ed9ec65"], //Metavixium Commonwealth
+        [document.getElementById("stateLabel13"), "aa783363-2892-424d-8da5-6087e4cde44a"], //Quixus
+        [document.getElementById("stateLabel12"), "fb7695aa-f638-42b2-9e86-18dabddfa1f1"], //Sedamixium
+        [document.getElementById("stateLabel15"), "1fbd1b6d-d026-4b99-bf4f-f4ffae2eb4d4"], //Hypnia
+        [document.getElementById("stateLabel9"), "5add2673-f8a0-4c88-bb26-eee00178f27a"], //Illuxtria
+        [document.getElementById("stateLabel2"), "27556c2f-a783-4fc0-a6e9-11d04de8254c"], //Namarus
+        [document.getElementById("stateLabel21"), "55a6941b-a414-4c9e-a04d-9cc9fd086aef"], //Wintexia
+        [document.getElementById("stateLabel1"), "e0945a07-26fb-46f4-a5d2-5592a28b96fd"], //Unholy Kingdom of Thay
+        [document.getElementById("stateLabel7"), "ad844d14-4ec1-4076-8e50-f8e6ca4e3e1b"], //Lintave
+
+        [document.getElementById("stateLabel22"), "2d8f7c26-c6e6-4cfb-a01e-abc189c2042e"], //Deadlands of Dolorex
+    ];
+
+    for (const [element, id] of labels) {
+        element.addEventListener("click", function () {
+            showModal(id, "{{site.locationUrlKey}}")
+        })
+    }
 }
 
 function makeLocationTabActive(id) {


### PR DESCRIPTION
Added CSS and JS to allow main labels (country, continent, some cities) to be clicked and will open the appropriate modal
