### PR TITLE
[issues-96] Add Flemington Planes location

### DIFF
--- a/collections/_locationsMaterialPlane/flemington-planes.html
+++ b/collections/_locationsMaterialPlane/flemington-planes.html
@@ -1,0 +1,11 @@
+---
+identifier: "cf6bb712-2570-495d-b420-22fb7182235f"
+name: "Flemington Planes"
+pronunciation: ""
+image: "flemington-planes.jpg"
+snippet: "Located ~8 hours to the west of Wolfhaven, this town is one of the most recent villages to fall victim to the Bhaalists."
+type: "Town"
+---
+<p>
+    A tiny, quiet town established only ten years ago by the kindly human Arthur Flemington, this town of barely twenty people was filled with kindly folk who kept to themselves and lives simple lives. Unfortunately, a recent attack on the village by Bhaalists has left everyone dead and Arthur completely dismembered. The horror witnessed by the party will not soon be forgotten.
+</p>


### PR DESCRIPTION
_Closes #96_

Adds a new `location`: Flemington Planes, with a map and a small description
