### PR TITLE
[issues-102] Update calendar and characters with Wolfhaven events

### DIFF
--- a/_sass/calendar.scss
+++ b/_sass/calendar.scss
@@ -104,6 +104,11 @@ $calendar-event-height: 22px;
     :nth-child(24 of .calendar-day)::before {
       content: "🌗";
     }
+
+    :nth-child(6n of .calendar-day)::after {
+      content: "💰";
+      text-align: right;
+    }
   }
 
   .calendar-day-header {

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -31,7 +31,7 @@
   const DAY_FULL_NAMES = ["Luxday", "Arday", "Ornday", "Tyrday", "Velday", "Nyxday"];
 
   // "Today" — change this single line to update the current date
-  const TODAY = { day: 6, month: 5, year: 7692 };
+  const TODAY = { day: 7, month: 5, year: 7692 };
 
   let currentMonth = TODAY.month;
   let currentYear = TODAY.year;

--- a/collections/_characters/reidoth.html
+++ b/collections/_characters/reidoth.html
@@ -23,7 +23,7 @@ isAlive: true
 </p>
 <hr/>
 <p>
-    After a fearful misunderstanding about a dragon sacrifice they fled the town. His current whereabouts are unknown.
+    After a fearful misunderstanding about a dragon sacrifice they fled the town. Their current whereabouts are unknown.
 </p>
 <hr/>
 <p>

--- a/collections/_characters/reidoth.html
+++ b/collections/_characters/reidoth.html
@@ -5,11 +5,11 @@ image: "reidoth.png"
 species: "badger"
 gender: "Nonbinary"
 occupation: "Druid"
-lastSeen: "Thundertree"
+lastSeen: "Wolfhaven / Old Lycanthrope"
 isAlive: true
 ---
 <blockquote>
-    "Sorry if I come off as strange, I'm just not very good with people. Animals I plants I get, but people
+    "Sorry if I come off as strange, I'm just not very good with people. Animals and plants I get, but people
     are... difficult for me." - Reidoth, when asked about their asocial behaviour
 </blockquote>
 <p>
@@ -23,5 +23,18 @@ isAlive: true
 </p>
 <hr/>
 <p>
-    After a fearful misunderstanding about a dragon sacrifice he fled the town. His current whereabouts are unknown.
+    After a fearful misunderstanding about a dragon sacrifice they fled the town. His current whereabouts are unknown.
+</p>
+<hr/>
+<p>
+    After receiving a Sending message from Gaelin asking to meet them and discuss setting up a new nest of giant spiders, Reidoth nervously agreed to meet the party in the nearby forest under the condition they speak at a distance as they were still uncertain how to feel about the party given previous misunderstandings about draconic sacrifice. Several days later, they agreed to meet in the northern forest near Wolfhaven.
+</p>
+<p>
+    Due to their nervousness, penchant for preferring animal forms, and a series of unfortunate events involving an early morning hunt with Peet and Gaelin, they were shot with an arrow in their deer form! Though very upset and worried about this all being a trick by the party to sacrifice them (again) Gaelin's silver tongue and quick thinking managed to soothe the druid long enough to allow Sýnchysi to meet with them and clarify things.
+</p>
+<p>
+    After speaking with Sýnchysi in a strange language that sounded like rustling leaves and wind gusts, they agreed to establish a new giant spider nest in the old lycanthrope den as long as Sýnchysi agrees to never allow any harm to come to them or their spiders, especially from party or the lycanthropes.
+</p>
+<p>
+    Sýnchysi agreed, and with a strange feel of old Nature magic binding their words, the deal was sealed and Reidoth took the queen spider egg, saying they would begin immediately preparing the nest for its new inhabitants.
 </p>

--- a/collections/_characters/reidoth.html
+++ b/collections/_characters/reidoth.html
@@ -5,7 +5,7 @@ image: "reidoth.png"
 species: "badger"
 gender: "Nonbinary"
 occupation: "Druid"
-lastSeen: "Wolfhaven / Old Lycanthrope"
+lastSeen: "Wolfhaven / Old Lycanthrope Den"
 isAlive: true
 ---
 <blockquote>

--- a/collections/_characters/reidoth.html
+++ b/collections/_characters/reidoth.html
@@ -27,7 +27,7 @@ isAlive: true
 </p>
 <hr/>
 <p>
-    After receiving a Sending message from Gaelin asking to meet them and discuss setting up a new nest of giant spiders, Reidoth nervously agreed to meet the party in the nearby forest under the condition they speak at a distance as they were still uncertain how to feel about the party given previous misunderstandings about draconic sacrifice. Several days later, they agreed to meet in the northern forest near Wolfhaven.
+    After receiving a Sending message from Gaelin asking to meet them and discuss setting up a new nest of giant spiders, Reidoth nervously agreed to meet the party in the nearby forest.
 </p>
 <p>
     Due to their nervousness, penchant for preferring animal forms, and a series of unfortunate events involving an early morning hunt with Peet and Gaelin, they were shot with an arrow in their deer form! Though very upset and worried about this all being a trick by the party to sacrifice them (again) Gaelin's silver tongue and quick thinking managed to soothe the druid long enough to allow Sýnchysi to meet with them and clarify things.

--- a/collections/_events/76920406-2_kaldoris_joins_the_party.html
+++ b/collections/_events/76920406-2_kaldoris_joins_the_party.html
@@ -7,9 +7,9 @@ year: 7692
 player: "Kaldoris"
 ---
 <p>
-    A suave bunny appeared from nowhere in the basement of the Redbrands Hideout. Sync vouched for them, join the party!
+    A suave bunny appeared from nowhere in the basement of the Redbrands Hideout. Sýnchysi vouched for them, join the party!
 </p>
 <hr/>
 <p>
-    While resting in the basement of the Redbrands Hideout, a very charismatic bunny suddenly appeared in front of them from nowhere seemingly as confused as the party was. However, Sync vouched for them saying they were friendly and would be a valuable asset to the team. Seeing his desire to do good and be a hero, the party welcomed him with open arms.
+    While resting in the basement of the Redbrands Hideout, a very charismatic bunny suddenly appeared in front of them from nowhere seemingly as confused as the party was. However, Sýnchysi vouched for them saying they were friendly and would be a valuable asset to the team. Seeing his desire to do good and be a hero, the party welcomed him with open arms.
 </p>

--- a/collections/_events/76920417-1_a_strange_door.html
+++ b/collections/_events/76920417-1_a_strange_door.html
@@ -7,12 +7,12 @@ year: 7692
 player: "Sýnchysi"
 ---
 <p>
-    A strange door appeared in Phandalin, and Sync enters it to meet a most perculiar naga.
+    A strange door appeared in Phandalin, and Sýnchysi enters it to meet a most perculiar naga.
 </p>
 <hr/>
 <p>
-    As Sync gathers their items to leave, the encounter a very strange ornate door on the side of a building. Deciding to look inside, they chance upon a very strange, otherworldly store run by a very strange naga named Vasuki.
+    As Sýnchysi gathers their items to leave, the encounter a very strange ornate door on the side of a building. Deciding to look inside, they chance upon a very strange, otherworldly store run by a very strange naga named Vasuki.
 </p>
 <p>
-    Vasuki welcomes them into their store, The Snake Oil Emporium, and offers to sell Sync a wide variety of strange and exotic items. Sync agrees and purchases a gift before leaving the strore and finding the door has disappeared behind them! Though strange, they do not think much on it before returning to the party, keeping this strange interaction to themself.
+    Vasuki welcomes them into their store, The Snake Oil Emporium, and offers to sell Sýnchysi a wide variety of strange and exotic items. Sýnchysi agrees and purchases a gift before leaving the strore and finding the door has disappeared behind them! Though strange, they do not think much on it before returning to the party, keeping this strange interaction to themself.
 </p>

--- a/collections/_events/76920425-2_baldurs_gate_departure.html
+++ b/collections/_events/76920425-2_baldurs_gate_departure.html
@@ -10,7 +10,7 @@ year: 7692
 </p>
 <hr/>
 <p>
-    After speaking with Sildar, they learn that the Lord's Alliance has already been informed by Goldblood about their supposed betrayal and will be arrested the soon, but should be able to stay a few days as long as they stay quite and undercover. Only to learn that Gaelin and Sync had previously made quite the commotion in the market district. Without the ability to remain under the radar, the party must think of an alternative plan, and quick!
+    After speaking with Sildar, they learn that the Lord's Alliance has already been informed by Goldblood about their supposed betrayal and will be arrested the soon, but should be able to stay a few days as long as they stay quite and undercover. Only to learn that Gaelin and Sýnchysi had previously made quite the commotion in the market district. Without the ability to remain under the radar, the party must think of an alternative plan, and quick!
 </p>
 <p>
     After some deliberation, the party decides to stage a escape but pretending to wound Sildar before escaping on horseback south to Tsendoric. Meanwhile they will double back and head north to Wolfhaven and Malgalus where they will be safer from prying eyes until this whole ordeal can be smoothed over.

--- a/collections/_events/76920502-2_first_meet_with_vargus.html
+++ b/collections/_events/76920502-2_first_meet_with_vargus.html
@@ -13,5 +13,5 @@ year: 7692
     Bringing along Peet to meet with the lycanthropes as well, the party is led to the lycanthrope's home den where they meet with Vargus who apologies again for scaring them last night as well as explaining what they are doing here. With Peet in tow, they explain that they wish to protect Wolfhaven and are glad to see their old friend again, though further details are vague.
 </p>
 <p>
-    Additionally, Fari's antics lead to them meeting with another lycanthrope - initially in quadrupedal form before transforming - who introduces himself as Darax. He seems to quite like the party, and is particularly drawn to Sync.
+    Additionally, Fari's antics lead to them meeting with another lycanthrope - initially in quadrupedal form before transforming - who introduces himself as Darax. He seems to quite like the party, and is particularly drawn to Sýnchysi.
 </p>

--- a/collections/_events/76920505-1_vasukis_promise.html
+++ b/collections/_events/76920505-1_vasukis_promise.html
@@ -21,5 +21,5 @@ year: 7692
 <hr/>
 
 <p>
-    Before leaving, Sync asks about bringing the spiders from Thundertree over to Wolfhaven. Vasuki says bringing them too close to the town would be dangerous, and he cannot bring them all, but he offers a queen spider egg to establish a new colony if they can find somewhere for them to live safely. Sync says he will look into it, and Vasuki says he will wait until the party gives the OK.
+    Before leaving, Sýnchysi asks about bringing the spiders from Thundertree over to Wolfhaven. Vasuki says bringing them too close to the town would be dangerous, and he cannot bring them all, but he offers a queen spider egg to establish a new colony if they can find somewhere for them to live safely. Sýnchysi says he will look into it, and Vasuki says he will wait until the party gives the OK.
 </p>

--- a/collections/_events/76920506-1_first_mine_payment.html
+++ b/collections/_events/76920506-1_first_mine_payment.html
@@ -1,0 +1,13 @@
+---
+identifier: "55adb292-4e7f-4656-9299-def09fdee072"
+title: "First Mine Payment"
+day: 6
+month: 5
+year: 7692
+---
+<p>
+    The Rockseeker brothers have finally finished setting up in The Phandelver Mine and have begun to excavate it. The first payment was sent to Vasuki - per group agreements - and then passed on to the party.
+</p>
+<p>
+    The brothers have said they will continue to send payments each week at regular intervals, although the amount will vary depending on what they uncover.
+</p>

--- a/collections/_events/76920506-2_reidoth_looking_after_spiders.html
+++ b/collections/_events/76920506-2_reidoth_looking_after_spiders.html
@@ -1,0 +1,14 @@
+---
+identifier: "5eb630e0-964a-4e73-9ea1-82a3c8eb5cda"
+title: "Reidoth to Look After Spiders"
+day: 6
+month: 5
+year: 7692
+player: "Sýnchysi"
+---
+<p>
+    After a bit of convincing, Reidoth has agreed to raise a new generation of giant spiders and raise them in the old lycanthrope den.
+</p>
+<p>
+    Although he has a queen spider egg, it will take at least 2-4 weeks for it to grow and begin to populate the new nest. In the meantime, Reidoth has asked for peace, privacy, and a promise to not be attacked.
+</p>

--- a/collections/_events/76920506-3_kaldoris_bandana.html
+++ b/collections/_events/76920506-3_kaldoris_bandana.html
@@ -10,5 +10,5 @@ player: "Kaldoris"
     After speaking with Vasuki - and paying his enchanting fee - Kaldoris handed over his and Harmony's bandanas to have them enchanted with special magic. The process will take approximately 4 days, but Vasuki promises to get in contact once they are ready to pick up.
 </p>
 <blockquote>
-    "And don't worry about needing to find me, my doors are always open to cute customers like you~" - Vasuki's parting words.
+    "And don't worry about needing to find me, my door is always open to cute customers like you~" - Vasuki's parting words.
 </blockquote>

--- a/collections/_events/76920506-3_kaldoris_bandana.html
+++ b/collections/_events/76920506-3_kaldoris_bandana.html
@@ -1,0 +1,14 @@
+---
+identifier: "281b1ff6-4020-4ecc-83ef-6a36fcac1131"
+title: "Bandana Enchanting"
+day: 6
+month: 5
+year: 7692
+player: "Kaldoris"
+---
+<p>
+    After speaking with Vasuki - and paying his enchanting fee - Kaldoris handed over his and Harmony's bandanas to have them enchanted with special magic. The process will take approximately 4 days, but Vasuki promises to get in contact once they are ready to pick up.
+</p>
+<blockquote>
+    "And don't worry about needing to find me, my doors are always open to cute customers like you~" - Vasuki's parting words.
+</blockquote>

--- a/collections/_events/76920506-4_bastions_fully_built.html
+++ b/collections/_events/76920506-4_bastions_fully_built.html
@@ -1,0 +1,13 @@
+---
+identifier: "feab4dee-4a37-493d-8725-d64f02bce459"
+title: "Bastions Fully Built"
+day: 6
+month: 5
+year: 7692
+---
+<p>
+    With the help of the lycanthropes and Vasuki's 'illusion', the bastions have been built in record time!
+</p>
+<p>
+    People are still moving in and will probably not be ready to begin projects until tomorrow, however.
+</p>


### PR DESCRIPTION
_Closes #102_

- Adds new important calendar events from last session
- Updated Reidoth's character sheet with Wolfhaven encounter info
- Updated all mentions of Sync to their proper name (Sýnchysi)
- Added a new icon to the calendar to indicate when the mine payments will be given to Vasuki and the party

